### PR TITLE
Fix Fileutils require

### DIFF
--- a/lib/localedata/installer.rb
+++ b/lib/localedata/installer.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Localedata
   class Installer
     def install(project_id)


### PR DESCRIPTION
Fixes the following error:

```
$ bundle exec localedata install "MYKEY"

bundler: failed to load command: localedata (lib/ruby/gems/3.0.0/bin/localedata)
lib/ruby/gems/3.0.0/bundler/gems/localedata-client-69dc08e606cc/lib/localedata/installer.rb:14:in `install': uninitialized constant Localedata::Installer::FileUtils (NameError)
Did you mean?  FileTest
	from /bundler/gems/localedata-client-69dc08e606cc/lib/localedata/cli.rb:8:in `install'
	from /gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /bundler/gems/localedata-client-69dc08e606cc/bin/localedata:4:in `<top (required)>'
	from bin/localedata:25:in `load'
	from bin/localedata:25:in `<top (required)>'
	from /gems/bundler-2.3.5/lib/bundler/cli/exec.rb:58:in `load'
	from /gems/bundler-2.3.5/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /gems/bundler-2.3.5/lib/bundler/cli/exec.rb:23:in `run'
	from /gems/bundler-2.3.5/lib/bundler/cli.rb:484:in `exec'
	from /gems/bundler-2.3.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /gems/bundler-2.3.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /gems/bundler-2.3.5/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /gems/bundler-2.3.5/lib/bundler/cli.rb:31:in `dispatch'
	from /gems/bundler-2.3.5/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /gems/bundler-2.3.5/lib/bundler/cli.rb:25:in `start'
	from /gems/bundler-2.3.5/exe/bundle:48:in `block in <top (required)>'
	from /gems/bundler-2.3.5/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	from /gems/bundler-2.3.5/exe/bundle:36:in `<top (required)>'
	from bin/bundle:23:in `load'
	from bin/bundle:23:in `<main>'
```